### PR TITLE
Converting to currency based lux

### DIFF
--- a/Assets/Scripts/Lights/LightController.cs
+++ b/Assets/Scripts/Lights/LightController.cs
@@ -9,6 +9,7 @@ public class LightController : MonoBehaviour
     public Light2D lightBeams;
 
     public bool startOn = false;
+    public bool returnsLux = false;
 
     [HideInInspector]
     public bool isOn;
@@ -75,7 +76,11 @@ public class LightController : MonoBehaviour
         }
         else
         {
-            StartCoroutine(EnableLight(endPos, startPos));
+            if(returnsLux) {
+                  StartCoroutine(EnableLight(endPos, startPos));
+            } else {
+                SwitchLightState();
+            }
         }
     }
 


### PR DESCRIPTION
Lights now consume lux when they are enabled. It is now a configurable option so choose if you want to want the lux to be returned when the light is disabled.
Resolves #194 