### PR TITLE
Tweaking Light Attraction

### DIFF
--- a/Assets/Scripts/Lights/LightAttraction.cs
+++ b/Assets/Scripts/Lights/LightAttraction.cs
@@ -44,12 +44,13 @@ public class LightAttraction : MonoBehaviour
         int layer_mask = LayerMask.GetMask("Terrain");
         centerOfLightMass = Vector2.zero;
         float totalIntensity = 0f;
-        foreach (Light2D light in lightsInScene)
+        List<Light2D> contributingLights = lightsInScene.FindAll(l => ShouldLightContribute(l, layer_mask));
+        int highestIntensity = FindHighestIntensity(contributingLights);
+
+        foreach (Light2D light in contributingLights)
         {
-            if (!ShouldLightContribute(light, layer_mask))
-            {
-                continue;
-            }
+            Debug.Log(light.name + " " + light.intensity + " " + highestIntensity);
+            if (light.intensity < highestIntensity) continue;
             centerOfLightMass += AddAttractionFromLight(light);
             totalIntensity += light.intensity;
         }
@@ -62,6 +63,19 @@ public class LightAttraction : MonoBehaviour
             centerOfLightMass /= totalIntensity;
         }
 
+    }
+
+    private int FindHighestIntensity(List<Light2D> lights)
+    {
+        int highestIntensity = 0;
+        foreach (Light2D light in lights)
+        {
+            if (light.intensity > highestIntensity)
+            {
+                highestIntensity = (int)light.intensity;
+            }
+        }
+        return highestIntensity;
     }
 
     private void FixedUpdate()


### PR DESCRIPTION
This PR changes the way that moths are attracted to light. This new system is a combination of the original system based on Free Body force diagrams and the new Center of Mass model. Moths now only care about the highest intensity light they can see.

If there is only one light of that highest intensity then the moths will be attracted directly on top of that light. However, if more than one light is tied for maximum intensity then the moths will go to the center point between all the visible lights of the highest intensity.
Resolves #188 