### PR TITLE
fixed the gaps between tiles

### DIFF
--- a/Assets/Sprites/Mossy - TileSet.png.meta
+++ b/Assets/Sprites/Mossy - TileSet.png.meta
@@ -3,7 +3,7 @@ guid: 5e0f837300062bd34aebe809d443cd53
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 11
+  serializedVersion: 12
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -47,7 +47,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 512
+  spritePixelsToUnits: 510
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -63,6 +63,7 @@ TextureImporter:
   textureFormatSet: 0
   ignorePngGamma: 0
   applyGammaDecoding: 0
+  cookieLightType: 1
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform


### PR DESCRIPTION
Fixed the weird flickering gap lines between times. Turns out that reducing the pixel per unit in tilemap renderer by 2 (512->510) solves the issue.

Resolves #187 